### PR TITLE
add support for xml comment while using XmlSerializerFormatAttribute

### DIFF
--- a/Source/.vs/WCFExtrasPlus/config/applicationhost.config
+++ b/Source/.vs/WCFExtrasPlus/config/applicationhost.config
@@ -173,7 +173,7 @@
                     <virtualDirectory path="/" physicalPath="D:\Users\Chris\Documents\My Web Sites\SampleServer-Site" />
                 </application>
                 <application path="/Sample" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="D:\personal\Works\WcfExtraPlusForked\wcfextrasplus-1\Source\SampleServer" />
+                    <virtualDirectory path="/" physicalPath="D:\development\src\wcfextrasplus\Source\SampleServer" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:80:localhost" />

--- a/Source/.vs/WCFExtrasPlus/config/applicationhost.config
+++ b/Source/.vs/WCFExtrasPlus/config/applicationhost.config
@@ -173,7 +173,7 @@
                     <virtualDirectory path="/" physicalPath="D:\Users\Chris\Documents\My Web Sites\SampleServer-Site" />
                 </application>
                 <application path="/Sample" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="D:\development\src\wcfextrasplus\Source\SampleServer" />
+                    <virtualDirectory path="/" physicalPath="D:\personal\Works\WcfExtraPlusForked\wcfextrasplus-1\Source\SampleServer" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:80:localhost" />


### PR DESCRIPTION
While using XmlSerializerFormat, the xml comments were invisible into the WSDL file. As the surrogate was only for datacontact, it could not create required annotations. But comparing the generated xml file in ExportEndpoint method, it can be workable even with XmlSerializerFormat. As there is not any compatible surrogate for XmlSerializerFormat, I think this can be a handy workaround. 